### PR TITLE
Parallel edges

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@
 # Please keep the list sorted.
 
 Vastech SA (PTY) LTD
+Xavier Chassin <xavier.chassin@live.fr>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,2 +1,1 @@
 Walter Schulze <awalterschulze@gmail.com>
-Xavier Chassin <xavier.chassin@live.fr>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,1 +1,2 @@
 Walter Schulze <awalterschulze@gmail.com>
+Xavier Chassin <xavier.chassin@live.fr>

--- a/analysewrite_test.go
+++ b/analysewrite_test.go
@@ -51,23 +51,23 @@ func assert(t *testing.T, msg string, v1 interface{}, v2 interface{}) {
 }
 
 func anal(t *testing.T, input string) Interface {
-	fmt.Printf("Input: %v\n", input)
+	t.Logf("Input: %v\n", input)
 	g, err := parser.ParseString(input)
 	check(t, err)
-	fmt.Printf("Parsed: %v\n", g)
+	t.Logf("Parsed: %v\n", g)
 	ag := NewGraph()
 	Analyse(g, ag)
-	fmt.Printf("Analysed: %v\n", ag)
+	t.Logf("Analysed: %v\n", ag)
 	agstr := ag.String()
-	fmt.Printf("Written: %v\n", agstr)
+	t.Logf("Written: %v\n", agstr)
 	g2, err := parser.ParseString(agstr)
 	check(t, err)
-	fmt.Printf("Parsed %v\n", g2)
+	t.Logf("Parsed %v\n", g2)
 	ag2 := NewEscape()
 	Analyse(g2, ag2)
-	fmt.Printf("Analysed %v\n", ag2)
+	t.Logf("Analysed %v\n", ag2)
 	ag2str := ag2.String()
-	fmt.Printf("Written: %v\n", ag2str)
+	t.Logf("Written: %v\n", ag2str)
 	assert(t, "analysed", agstr, ag2str)
 	return ag2
 }

--- a/edges.go
+++ b/edges.go
@@ -87,11 +87,5 @@ func (es edgeSorter) Less(i, j int) bool {
 		return false
 	}
 
-	iLabel := es[i].Attrs["label"]
-	jLabel := es[j].Attrs["label"]
-	if iLabel < jLabel {
-		return true
-	}
-
-	return false
+	return es[i].Attrs["label"] < es[j].Attrs["label"]
 }

--- a/edges.go
+++ b/edges.go
@@ -69,7 +69,6 @@ func (this Edges) Sorted() []*Edge {
 	return es
 }
 
-// edgeSorter is an internal struct used for sorting edges
 type edgeSorter []*Edge
 
 func (es edgeSorter) Len() int      { return len(es) }

--- a/edges.go
+++ b/edges.go
@@ -63,21 +63,35 @@ func (this *Edges) Add(edge *Edge) {
 
 //Returns a sorted list of Edges.
 func (this Edges) Sorted() []*Edge {
-	srcs := make([]string, 0, len(this.SrcToDsts))
-	for src := range this.SrcToDsts {
-		srcs = append(srcs, src)
+	es := make(edgeSorter, len(this.Edges))
+	copy(es, this.Edges)
+	sort.Sort(es)
+	return es
+}
+
+// edgeSorter is an internal struct used for sorting edges
+type edgeSorter []*Edge
+
+func (es edgeSorter) Len() int      { return len(es) }
+func (es edgeSorter) Swap(i, j int) { es[i], es[j] = es[j], es[i] }
+func (es edgeSorter) Less(i, j int) bool {
+	if es[i].Src < es[j].Src {
+		return true
+	} else if es[i].Src > es[j].Src {
+		return false
 	}
-	sort.Strings(srcs)
-	edges := make([]*Edge, 0, len(srcs))
-	for _, src := range srcs {
-		dsts := make([]string, 0, len(this.SrcToDsts[src]))
-		for dst := range this.SrcToDsts[src] {
-			dsts = append(dsts, dst)
-		}
-		sort.Strings(dsts)
-		for _, dst := range dsts {
-			edges = append(edges, this.SrcToDsts[src][dst]...)
-		}
+
+	if es[i].Dst < es[j].Dst {
+		return true
+	} else if es[i].Dst > es[j].Dst {
+		return false
 	}
-	return edges
+
+	iLabel := es[i].Attrs["label"]
+	jLabel := es[j].Attrs["label"]
+	if iLabel < jLabel {
+		return true
+	}
+
+	return false
 }

--- a/edges.go
+++ b/edges.go
@@ -61,7 +61,7 @@ func (this *Edges) Add(edge *Edge) {
 	this.Edges = append(this.Edges, edge)
 }
 
-//Retrusn a sorted list of Edges.
+//Returns a sorted list of Edges.
 func (this Edges) Sorted() []*Edge {
 	srcs := make([]string, 0, len(this.SrcToDsts))
 	for src := range this.SrcToDsts {

--- a/edges.go
+++ b/edges.go
@@ -30,32 +30,34 @@ type Edge struct {
 
 //Represents a set of Edges.
 type Edges struct {
-	SrcToDsts map[string]map[string]*Edge
-	DstToSrcs map[string]map[string]*Edge
+	SrcToDsts map[string]map[string][]*Edge
+	DstToSrcs map[string]map[string][]*Edge
 	Edges     []*Edge
 }
 
 //Creates a blank set of Edges.
 func NewEdges() *Edges {
-	return &Edges{make(map[string]map[string]*Edge), make(map[string]map[string]*Edge), make([]*Edge, 0)}
+	return &Edges{make(map[string]map[string][]*Edge), make(map[string]map[string][]*Edge), make([]*Edge, 0)}
 }
 
 //Adds an Edge to the set of Edges.
 func (this *Edges) Add(edge *Edge) {
 	if _, ok := this.SrcToDsts[edge.Src]; !ok {
-		this.SrcToDsts[edge.Src] = make(map[string]*Edge)
+		this.SrcToDsts[edge.Src] = make(map[string][]*Edge)
 	}
 	if _, ok := this.SrcToDsts[edge.Src][edge.Dst]; !ok {
-		this.SrcToDsts[edge.Src][edge.Dst] = edge
-	} else {
-		this.SrcToDsts[edge.Src][edge.Dst].Attrs.Extend(edge.Attrs)
+		this.SrcToDsts[edge.Src][edge.Dst] = make([]*Edge, 0)
 	}
+	this.SrcToDsts[edge.Src][edge.Dst] = append(this.SrcToDsts[edge.Src][edge.Dst], edge)
+
 	if _, ok := this.DstToSrcs[edge.Dst]; !ok {
-		this.DstToSrcs[edge.Dst] = make(map[string]*Edge)
+		this.DstToSrcs[edge.Dst] = make(map[string][]*Edge)
 	}
 	if _, ok := this.DstToSrcs[edge.Dst][edge.Src]; !ok {
-		this.DstToSrcs[edge.Dst][edge.Src] = edge
+		this.DstToSrcs[edge.Dst][edge.Src] = make([]*Edge, 0)
 	}
+	this.DstToSrcs[edge.Dst][edge.Src] = append(this.DstToSrcs[edge.Dst][edge.Src], edge)
+
 	this.Edges = append(this.Edges, edge)
 }
 
@@ -74,7 +76,7 @@ func (this Edges) Sorted() []*Edge {
 		}
 		sort.Strings(dsts)
 		for _, dst := range dsts {
-			edges = append(edges, this.SrcToDsts[src][dst])
+			edges = append(edges, this.SrcToDsts[src][dst]...)
 		}
 	}
 	return edges

--- a/edges.go
+++ b/edges.go
@@ -86,5 +86,34 @@ func (es edgeSorter) Less(i, j int) bool {
 		return false
 	}
 
-	return es[i].Attrs["label"] < es[j].Attrs["label"]
+	if es[i].SrcPort < es[j].SrcPort {
+		return true
+	} else if es[i].SrcPort > es[j].SrcPort {
+		return false
+	}
+
+	if es[i].DstPort < es[j].DstPort {
+		return true
+	} else if es[i].DstPort > es[j].DstPort {
+		return false
+	}
+
+	if es[i].Dir != es[j].Dir {
+		return es[i].Dir
+	}
+
+	attrs := es[i].Attrs.Copy()
+	for k, v := range es[j].Attrs {
+		attrs[k] = v
+	}
+
+	for _, k := range attrs.SortedNames() {
+		if es[i].Attrs[k] < es[j].Attrs[k] {
+			return true
+		} else if es[i].Attrs[k] > es[j].Attrs[k] {
+			return false
+		}
+	}
+
+	return false
 }

--- a/edges_test.go
+++ b/edges_test.go
@@ -1,0 +1,115 @@
+//Copyright 2013 Vastech SA (PTY) LTD
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package gographviz
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEdges_Sorted(t *testing.T) {
+	var tts = map[string]struct {
+		edges    []*Edge
+		expected []*Edge
+	}{
+		"empty": {
+			edges:    []*Edge{},
+			expected: []*Edge{},
+		},
+		"one edge": {
+			edges: []*Edge{
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "abc"}},
+			},
+			expected: []*Edge{
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "abc"}},
+			},
+		},
+		"two non parallel edges": {
+			edges: []*Edge{
+				&Edge{Src: "0", Dst: "2", Attrs: map[string]string{"label": "hello"}},
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "abc"}},
+			},
+			expected: []*Edge{
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "abc"}},
+				&Edge{Src: "0", Dst: "2", Attrs: map[string]string{"label": "hello"}},
+			},
+		},
+		"two parallel edges": {
+			edges: []*Edge{
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "hello"}},
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "abc"}},
+			},
+			expected: []*Edge{
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "abc"}},
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "hello"}},
+			},
+		},
+		"two parallel edges - one without label": {
+			edges: []*Edge{
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "abc"}},
+				&Edge{Src: "0", Dst: "1"},
+			},
+			expected: []*Edge{
+				&Edge{Src: "0", Dst: "1"},
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "abc"}},
+			},
+		},
+		"several non parallel edges": {
+			edges: []*Edge{
+				&Edge{Src: "0", Dst: "2", Attrs: map[string]string{"label": "hello"}},
+				&Edge{Src: "1", Dst: "1", Attrs: map[string]string{"label": "world"}},
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "abc"}},
+				&Edge{Src: "1", Dst: "0", Attrs: map[string]string{"label": "golang"}},
+			},
+			expected: []*Edge{
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "abc"}},
+				&Edge{Src: "0", Dst: "2", Attrs: map[string]string{"label": "hello"}},
+				&Edge{Src: "1", Dst: "0", Attrs: map[string]string{"label": "golang"}},
+				&Edge{Src: "1", Dst: "1", Attrs: map[string]string{"label": "world"}},
+			},
+		},
+		"several with parallel edges": {
+			edges: []*Edge{
+				&Edge{Src: "0", Dst: "2", Attrs: map[string]string{"label": "hello"}},
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "cba"}},
+				&Edge{Src: "1", Dst: "1", Attrs: map[string]string{"label": "world"}},
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "abc"}},
+				&Edge{Src: "1", Dst: "0", Attrs: map[string]string{"label": "gopher"}},
+				&Edge{Src: "1", Dst: "0", Attrs: map[string]string{"label": "golang"}},
+			},
+			expected: []*Edge{
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "abc"}},
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "cba"}},
+				&Edge{Src: "0", Dst: "2", Attrs: map[string]string{"label": "hello"}},
+				&Edge{Src: "1", Dst: "0", Attrs: map[string]string{"label": "golang"}},
+				&Edge{Src: "1", Dst: "0", Attrs: map[string]string{"label": "gopher"}},
+				&Edge{Src: "1", Dst: "1", Attrs: map[string]string{"label": "world"}},
+			},
+		},
+	}
+
+	for name, tt := range tts {
+		edges := NewEdges()
+		for _, e := range tt.edges {
+			edges.Add(e)
+		}
+		s := edges.Sorted()
+		if !reflect.DeepEqual(tt.expected, s) {
+			t.Errorf("%s - Sorted invalid: expected %v got %v", name, tt.expected, s)
+		} else if !reflect.DeepEqual(edges.Edges, tt.edges) {
+			t.Errorf("%s - Sorted should not have changed original order: expected %v got %v", name, tt.edges, edges.Edges)
+		}
+	}
+}

--- a/edges_test.go
+++ b/edges_test.go
@@ -1,4 +1,4 @@
-//Copyright 2013 Vastech SA (PTY) LTD
+//Copyright 2013 GoGraphviz Authors
 //
 //Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.

--- a/edges_test.go
+++ b/edges_test.go
@@ -98,6 +98,68 @@ func TestEdges_Sorted(t *testing.T) {
 				&Edge{Src: "1", Dst: "1", Attrs: map[string]string{"label": "world"}},
 			},
 		},
+		"edges with ports": {
+			edges: []*Edge{
+				&Edge{Src: "0", Dst: "1", SrcPort: "a", DstPort: "b"},
+				&Edge{Src: "0", Dst: "1", SrcPort: "a", DstPort: "a"},
+				&Edge{Src: "0", Dst: "1", SrcPort: "b", DstPort: "a"},
+			},
+			expected: []*Edge{
+				&Edge{Src: "0", Dst: "1", SrcPort: "a", DstPort: "a"},
+				&Edge{Src: "0", Dst: "1", SrcPort: "a", DstPort: "b"},
+				&Edge{Src: "0", Dst: "1", SrcPort: "b", DstPort: "a"},
+			},
+		},
+		"directed edges before non directed edges": {
+			edges: []*Edge{
+				&Edge{Src: "0", Dst: "1", Dir: false},
+				&Edge{Src: "0", Dst: "1", Dir: true},
+			},
+			expected: []*Edge{
+				&Edge{Src: "0", Dst: "1", Dir: true},
+				&Edge{Src: "0", Dst: "1", Dir: false},
+			},
+		},
+		"the theory of everything": {
+			edges: []*Edge{
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "cba"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "a", Dir: false, Attrs: map[string]string{"label": "gopher"}},
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "abc"}},
+				&Edge{Src: "0", Dst: "2", Attrs: map[string]string{"label": "hello"}},
+				&Edge{Src: "1", Dst: "0", Attrs: map[string]string{"label": "gopher"}},
+				&Edge{Src: "1", Dst: "0", Attrs: map[string]string{"label": "golang"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "b", Attrs: map[string]string{"label": "gopher"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "a", DstPort: "b", Attrs: map[string]string{"label": "golang"}},
+				&Edge{Src: "1", Dst: "1", Attrs: map[string]string{"comment": "test", "label": "world"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "a", DstPort: "a", Attrs: map[string]string{"label": "golang"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "a", Attrs: map[string]string{"label": "golang"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "b", Dir: false, Attrs: map[string]string{"label": "gopher"}},
+				&Edge{Src: "1", Dst: "1", Attrs: map[string]string{"label": "world"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "a", DstPort: "b", Dir: true, Attrs: map[string]string{"label": "golang"}},
+				&Edge{Src: "1", Dst: "1", Attrs: map[string]string{"comment": "test", "label": "hello"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "a", Dir: true, Attrs: map[string]string{"label": "golang"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "a", DstPort: "b", Dir: true, Attrs: map[string]string{"label": "graphviz"}},
+			},
+			expected: []*Edge{
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "abc"}},
+				&Edge{Src: "0", Dst: "1", Attrs: map[string]string{"label": "cba"}},
+				&Edge{Src: "0", Dst: "2", Attrs: map[string]string{"label": "hello"}},
+				&Edge{Src: "1", Dst: "0", Attrs: map[string]string{"label": "golang"}},
+				&Edge{Src: "1", Dst: "0", Attrs: map[string]string{"label": "gopher"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "a", Dir: true, Attrs: map[string]string{"label": "golang"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "a", Attrs: map[string]string{"label": "golang"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "a", Dir: false, Attrs: map[string]string{"label": "gopher"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "a", DstPort: "a", Attrs: map[string]string{"label": "golang"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "a", DstPort: "b", Dir: true, Attrs: map[string]string{"label": "golang"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "a", DstPort: "b", Dir: true, Attrs: map[string]string{"label": "graphviz"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "a", DstPort: "b", Attrs: map[string]string{"label": "golang"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "b", Dir: false, Attrs: map[string]string{"label": "gopher"}},
+				&Edge{Src: "1", Dst: "0", SrcPort: "b", Attrs: map[string]string{"label": "gopher"}},
+				&Edge{Src: "1", Dst: "1", Attrs: map[string]string{"label": "world"}},
+				&Edge{Src: "1", Dst: "1", Attrs: map[string]string{"comment": "test", "label": "hello"}},
+				&Edge{Src: "1", Dst: "1", Attrs: map[string]string{"comment": "test", "label": "world"}},
+			},
+		},
 	}
 
 	for name, tt := range tts {


### PR DESCRIPTION
Hi!

First, very good work on the lib! I see you're quite active on it, which is always a pleasure 😃

This PR adds support to parallel edges.
Let's say that, for reasons, I have the following graph:
```dot
digraph {
    0 [label=from];
    1 [label=to];
    0 -> 1 [label=hello];
    0 -> 1 [label=world];
}
```

If I
```go
g := gographvizNewGraph()
g.SetDir(true)

// Add nodes
g.AddNode(g.Name, "0", map[string]string{"label": "from"})
g.AddNode(g.Name, "1", map[string]string{"label": "to"})
// Now add edges
g.AddEdge("0", "1", true, map[string]string{"label": "hello"})
g.AddEdge("0", "1", true, map[string]string{"label": "world"})

fmt.Println(g.String())
```
it generates
```dot
digraph  {
    0->1[ label=world ]; // <-- label should be hello
    0->1[ label=world ];
    0 [ label=from ];
    1 [ label=to ];
}
```

The problem also (logically) arises if I parse the first dot block (with `parser.ParseString`), uses the `Analyse` to populate a `Graph` and then `g.String()` it.

The tests seem to still pass without additional work, but I am not fully convinced I do not break some things. For example the `Sorted` method on `Edges` was fixed to compile, but not tested further than that.