### PR TITLE
Return specific types for Read and NewAnalysedGraph

### DIFF
--- a/analyse.go
+++ b/analyse.go
@@ -19,7 +19,7 @@ import (
 )
 
 //Creates a Graph structure by analysing an Abstract Syntax Tree representing a parsed graph.
-func NewAnalysedGraph(graph *ast.Graph) Interface {
+func NewAnalysedGraph(graph *ast.Graph) *Graph {
 	g := NewGraph()
 	Analyse(graph, g)
 	return g

--- a/gographviz.go
+++ b/gographviz.go
@@ -44,7 +44,7 @@ func Parse(buf []byte) (*ast.Graph, error) {
 }
 
 //Parses and creates a new Graph from the data.
-func Read(buf []byte) (Interface, error) {
+func Read(buf []byte) (*Graph, error) {
 	st, err := Parse(buf)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Makes the returned values more immediately usable as type assertions are no longer required.
