### PR TITLE
Make cluster subgraphs as nodes for edges

### DIFF
--- a/escape_test.go
+++ b/escape_test.go
@@ -45,3 +45,34 @@ func TestEscape(t *testing.T) {
 		t.Fatalf("should be a node")
 	}
 }
+
+func TestClusterSubgraphs(t *testing.T) {
+	g := NewEscape()
+	g.SetName("G")
+	g.SetDir(false)
+	g.AddSubGraph("G", "cluster0", nil)
+	g.AddSubGraph("cluster0", "cluster_1", nil)
+	g.AddSubGraph("cluster0", "cluster_2", nil)
+	g.AddNode("G", "Code deployment", nil)
+	g.AddPortEdge("cluster_2", "", "cluster_1", "", false, nil)
+	s := g.String()
+	if !strings.HasPrefix(s, `graph G {
+	cluster_2--cluster_1;
+	subgraph cluster0 {
+	subgraph cluster_1 {
+
+}
+;
+	subgraph cluster_2 {
+
+}
+;
+
+}
+;
+	"Code deployment";
+
+}`) {
+		t.Fatalf("%s", s)
+	}
+}

--- a/graph.go
+++ b/graph.go
@@ -14,6 +14,8 @@
 
 package gographviz
 
+import "strings"
+
 //The analysed representation of the Graph parsed from the DOT format.
 type Graph struct {
 	Attrs     Attrs
@@ -111,4 +113,10 @@ func (this *Graph) IsNode(name string) bool {
 func (this *Graph) IsSubGraph(name string) bool {
 	_, ok := this.SubGraphs.SubGraphs[name]
 	return ok
+}
+
+func (this *Graph) IsClusterSubGraph(name string) bool {
+	isSubGraph := this.IsSubGraph(name)
+	isCluster := strings.HasPrefix(name, "cluster")
+	return isSubGraph && isCluster
 }

--- a/write.go
+++ b/write.go
@@ -77,6 +77,11 @@ func (this *writer) newNodeStmt(name string) *ast.NodeStmt {
 func (this *writer) newLocation(name string, port string) ast.Location {
 	if this.IsNode(name) {
 		return this.newNodeId(name, port)
+	} else if this.IsClusterSubGraph(name) {
+		if len(port) != 0 {
+			panic(fmt.Sprintf("subgraph cannot have a port: %v", port))
+		}
+		return ast.MakeNodeId(name, port)
 	} else if this.IsSubGraph(name) {
 		if len(port) != 0 {
 			panic(fmt.Sprintf("subgraph cannot have a port: %v", port))


### PR DESCRIPTION
There's an issue where making edges between cluster subgraphs (which are useful with fdp) would double subgraphs in output string.

Consider this code:
```go
g := gographviz.NewEscape()
g.SetName("G")
g.SetDir(false)
g.AddSubGraph("G", "cluster0", map[string]string{"label": "root"})
g.AddSubGraph("cluster0", "cluster_1", map[string]string{"label": "child 1"})
g.AddSubGraph("cluster0", "cluster_2", map[string]string{"label": "child 2"})
nodeStyle := map[string]string{"style": "rounded"}
g.AddNode("cluster_1", "1", nodeStyle)
g.AddNode("cluster_1", "2", nodeStyle)
g.AddNode("cluster_2", "3", nodeStyle)
g.AddNode("cluster_2", "4", nodeStyle)
g.AddNode("G", "Code deployment", map[string]string{"style": "dotted"})
g.AddPortEdge("cluster_2", "", "cluster_1", "", false, nil)
s := g.String()
fmt.Println(s)
```


It currently renders such code, which is incorrect and would not render:

graph G {
        subgraph cluster_2 {
        label="child 2";
        3 [ style=rounded ];
        4 [ style=rounded ];

}
**--subgraph cluster_1 {**
        label="child 1";
        1 [ style=rounded ];
        2 [ style=rounded ];

};
        subgraph cluster0 {
        label=root;
        subgraph cluster_1 {
        label="child 1";
        1 [ style=rounded ];
        2 [ style=rounded ];

}
;
        subgraph cluster_2 {
        label="child 2";
        3 [ style=rounded ];
        4 [ style=rounded ];

}
;

}
;
        "Code deployment" [ style=dotted ];

}

After the patch applied it would make such code (subgraphs starting with cluster would be rendered as nodes for edges):
graph G {
        **cluster_2--cluster_1;**
        subgraph cluster0 {
        label=root;
        subgraph cluster_1 {
        label="child 1";
        1 [ style=rounded ];
        2 [ style=rounded ];

}
;
        subgraph cluster_2 {
        label="child 2";
        3 [ style=rounded ];
        4 [ style=rounded ];

}
;

}
;
        "Code deployment" [ style=dotted ];

}


