### PR TITLE
Add the sometimes missing "strict" keyword on graph declaration

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -104,7 +104,11 @@ func NewGraph(t, strict, id, l Attrib) (*Graph, error) {
 }
 
 func (this *Graph) String() string {
-	s := this.Type.String() + " " + this.ID.String() + " {\n"
+	var s string
+	if this.Strict {
+		s += "strict "
+	}
+	s += this.Type.String() + " " + this.ID.String() + " {\n"
 	if this.StmtList != nil {
 		s += this.StmtList.String()
 	}


### PR DESCRIPTION
According to http://www.graphviz.org/content/dot-language, a graph is declared using the following statement:
```
graph: [ strict ] (graph | digraph) [ ID ] '{' stmt_list '}'
```
This patch adds, during the generation of the string representation, the `strict` keyword that is missing when `Graph.Strict` values true.

Cheers,
X-Cli

