### PR TITLE
Fix index out of range error

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -596,9 +596,9 @@ func MakeNodeID(id string, port string) *NodeID {
 	p := Port{"", ""}
 	if len(port) > 0 {
 		ps := strings.Split(port, ":")
-		p.ID1 = ID(ps[1])
+		p.ID1 = ID(ps[0])
 		if len(ps) > 2 {
-			p.ID2 = ID(ps[2])
+			p.ID2 = ID(ps[1])
 		}
 	}
 	return &NodeID{ID(id), p}

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -597,7 +597,7 @@ func MakeNodeID(id string, port string) *NodeID {
 	if len(port) > 0 {
 		ps := strings.Split(port, ":")
 		p.ID1 = ID(ps[0])
-		if len(ps) > 2 {
+		if len(ps) > 1 {
 			p.ID2 = ID(ps[1])
 		}
 	}

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -1,0 +1,46 @@
+package ast
+
+import (
+	"testing"
+)
+
+func TestMakeNodeID(t *testing.T) {
+	tcs := []struct {
+		id   string
+		port string
+		want NodeID
+	}{
+		{ // TC#1
+			id:   "",
+			port: "",
+			want: NodeID{}},
+		{ // TC#2
+			id:   "id",
+			port: "p1",
+			want: NodeID{"id", Port{"p1", ""}},
+		},
+		{ // TC#3
+			id:   "_id",
+			port: "p1:p2",
+			want: NodeID{"_id", Port{"p1", "p2"}},
+		},
+		{ // TC#4
+			id:   "1id",
+			port: "p1:p2:p3",
+			want: NodeID{"1id", Port{"p1", "p2"}},
+		},
+		{ // TC#5
+			id:   "?id",
+			port: ":p2:p3",
+			want: NodeID{"?id", Port{"", "p2"}},
+		},
+	}
+
+	for i, tc := range tcs {
+		n := MakeNodeID(tc.id, tc.port)
+
+		if *n != tc.want {
+			t.Fatalf("TC#%d: MakeNodeId(%q, %q)=%#v, want %#v", i+1, tc.id, tc.port, *n, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Fix index out of range error when use complex edge's port:
```graph.AddPortEdge("srcNode","srcPort:n","dstNode", "dstPort:w", true, nil)```