### PR TITLE
Escape names containing a slash

### DIFF
--- a/escape.go
+++ b/escape.go
@@ -75,6 +75,9 @@ func isID(s string) bool {
 		if c == '-' {
 			return false
 		}
+		if c == '/' {
+			return false
+		}
 		i++
 	}
 	return pos

--- a/escape_test.go
+++ b/escape_test.go
@@ -43,10 +43,14 @@ func TestEscape(t *testing.T) {
 	if err := g.AddEdge("kasdf99 99", "7", true, nil); err != nil {
 		t.Fatal(err)
 	}
+	if err := g.AddNode("asdf asdf", "a/b", nil); err != nil {
+		t.Fatal(err)
+	}
 	s := g.String()
 	if !strings.HasPrefix(s, `digraph "asdf adsf" {
 	"kasdf99 99"->7;
 	"a &lt;&lt; b";
+	"a/b";
 	"kasdf99 99" [ URL="<a" ];
 	7 [ URL="<a" ];
 


### PR DESCRIPTION
A graph, node, or edge name containing a slash must be escaped. Otherwise, graphviz can't parse it.