### PR TITLE
attr: add ImagePos

### DIFF
--- a/analysewrite_test.go
+++ b/analysewrite_test.go
@@ -106,6 +106,11 @@ func TestString(t *testing.T) {
 		`digraph finite_state { rankdir = "LR" }`)
 }
 
+func TestAttrImgPos(t *testing.T) {
+	anal(t,
+		"digraph finite_state { imagepos = tc }")
+}
+
 func TestAttrList(t *testing.T) {
 	anal(t, `
 digraph { node [ shape = doublecircle ] }`)

--- a/attr.go
+++ b/attr.go
@@ -141,6 +141,8 @@ const (
 	Image Attr = "image"
 	// ImagePath http://graphviz.gitlab.io/_pages/doc/info/attrs.html#d:imagepath
 	ImagePath Attr = "imagepath"
+	// ImagePos https://graphviz.org/doc/info/attrs.html#d:imagepos
+	ImagePos Attr = "imagepos"
 	// ImageScale http://graphviz.gitlab.io/_pages/doc/info/attrs.html#d:imagescale
 	ImageScale Attr = "imagescale"
 	// InputScale http://graphviz.gitlab.io/_pages/doc/info/attrs.html#d:inputscale
@@ -437,6 +439,7 @@ var validAttrs = map[string]Attr{
 	string(ID):                 ID,
 	string(Image):              Image,
 	string(ImagePath):          ImagePath,
+	string(ImagePos):           ImagePos,
 	string(ImageScale):         ImageScale,
 	string(InputScale):         InputScale,
 	string(Label):              Label,


### PR DESCRIPTION
Hi, 

I'd like to merge this attribute `ImagePos` (https://graphviz.org/doc/info/attrs.html#d:imagepos). Let me know if I need to add tests / other things. :smiley: 

This attribute can only support a set of value:

* tl | Top Left
* tc | Top Centered
* tr | Top Right
* ml | Middle Left
* mc | Middle Centered (the default)
* mr | Middle Right
* bl | Bottom Left
* bc | Bottom Centered
* br | Bottom Right

Do we want to add a way to verify the value given by the user for this attribute ? 
