### PR TITLE
Add go module support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/awalterschulze/gographviz
+
+go 1.13


### PR DESCRIPTION
Add `go module` support for this project. Because this project has no external dependencies, the automatically generated `go.mod` is almost empty.

`go module` is enabled by default no earlier than Golang 1.13 (released 2019/09/03), thus Golang version is specified as 1.13 here. Hope this won't cause unexpected conflicts, so I ran all unit tests locally (Darwin 18.7.0) and all of them were passed. 

Fixes #63 