### PR TITLE
Fix Go module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/awalterschulze/gographviz
+module github.com/awalterschulze/gographviz/v2
 
 go 1.13


### PR DESCRIPTION
From https://blog.golang.org/using-go-modules:

> Each different major version (v1, v2, and so on) of a Go module uses a different module path: starting at v2, the path must end in the major version. In the example, v3 of rsc.io/quote is no longer rsc.io/quote: instead, it is identified by the module path rsc.io/quote/v3. This convention is called semantic import versioning

Currently running `go mod download` in a module using `github.com/awalterschulze/gographviz` in version `v2.0.2` results in the following error:

> github.com/awalterschulze/gographviz@v2.0.2+incompatible: invalid version: +incompatible suffix not allowed: module contains a go.mod file, so semantic import versioning is required