### PR TITLE
Better block indentation

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -728,10 +728,3 @@ func (this ID) Walk(v Visitor) {
 	}
 	v.Visit(this)
 }
-
-func genIndent(lvl int) (idt string) {
-	for i := 0; i < lvl; i++ {
-		idt += "\t"
-	}
-	return idt
-}

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -110,10 +110,9 @@ func (this *Graph) String() string {
 	if this.Strict {
 		s += "strict "
 	}
-	s += this.Type.String() + " " + this.ID.String() + " {\n\t"
+	s += this.Type.String() + " " + this.ID.String() + " {\n"
 	if this.StmtList != nil {
-		lines := strings.Split(this.StmtList.String(), "\n")
-		s += strings.Join(lines, "\n\t")
+		s += this.StmtList.indentString("\t")
 	}
 	s += "\n}\n"
 	return s
@@ -144,12 +143,16 @@ func AppendStmtList(ss, s Attrib) (StmtList, error) {
 }
 
 func (this StmtList) String() string {
+	return this.indentString("")
+}
+
+func (this StmtList) indentString(indent string) string {
 	if len(this) == 0 {
 		return ""
 	}
 	s := ""
 	for i := 0; i < len(this); i++ {
-		ss := this[i].String()
+		ss := this[i].indentString(indent)
 		if len(ss) > 0 {
 			s += ss + ";\n"
 		}
@@ -172,6 +175,7 @@ type Stmt interface {
 	Elem
 	Walkable
 	isStmt()
+	indentString(string) string
 }
 
 func (this NodeStmt) isStmt()   {}
@@ -218,16 +222,20 @@ func (this *SubGraph) GetPort() Port {
 }
 
 func (this *SubGraph) String() string {
+	return this.indentString("")
+}
+
+func (this *SubGraph) indentString(indent string) string {
 	gName := this.ID.String()
 	if strings.HasPrefix(gName, "anon") {
 		gName = ""
 	}
-	s := "subgraph " + this.ID.String() + " {\n\t"
+
+	s := indent + "subgraph " + this.ID.String() + " {\n"
 	if this.StmtList != nil {
-		lines := strings.Split(this.StmtList.String(), "\n")
-		s += strings.Join(lines, "\n\t")
+		s += this.StmtList.indentString(indent + "\t")
 	}
-	s += "\n}"
+	s += "\n" + indent + "}"
 	return s
 }
 
@@ -247,11 +255,15 @@ func NewEdgeAttrs(a Attrib) (EdgeAttrs, error) {
 }
 
 func (this EdgeAttrs) String() string {
+	return this.indentString("")
+}
+
+func (this EdgeAttrs) indentString(indent string) string {
 	s := AttrList(this).String()
 	if len(s) == 0 {
 		return ""
 	}
-	return `edge ` + s
+	return indent + `edge ` + s
 }
 
 func (this EdgeAttrs) Walk(v Visitor) {
@@ -271,11 +283,15 @@ func NewNodeAttrs(a Attrib) (NodeAttrs, error) {
 }
 
 func (this NodeAttrs) String() string {
+	return this.indentString("")
+}
+
+func (this NodeAttrs) indentString(indent string) string {
 	s := AttrList(this).String()
 	if len(s) == 0 {
 		return ""
 	}
-	return `node ` + s
+	return indent + `node ` + s
 }
 
 func (this NodeAttrs) Walk(v Visitor) {
@@ -295,11 +311,15 @@ func NewGraphAttrs(a Attrib) (GraphAttrs, error) {
 }
 
 func (this GraphAttrs) String() string {
+	return this.indentString("")
+}
+
+func (this GraphAttrs) indentString(indent string) string {
 	s := AttrList(this).String()
 	if len(s) == 0 {
 		return ""
 	}
-	return `graph ` + s
+	return indent + `graph ` + s
 }
 
 func (this GraphAttrs) Walk(v Visitor) {
@@ -432,7 +452,11 @@ func NewAttr(f, v Attrib) (*Attr, error) {
 }
 
 func (this *Attr) String() string {
-	return this.Field.String() + `=` + this.Value.String()
+	return this.indentString("")
+}
+
+func (this *Attr) indentString(indent string) string {
+	return indent + this.Field.String() + `=` + this.Value.String()
 }
 
 func (this *Attr) Walk(v Visitor) {
@@ -479,7 +503,11 @@ func NewEdgeStmt(id, e, attrs Attrib) (*EdgeStmt, error) {
 }
 
 func (this EdgeStmt) String() string {
-	return strings.TrimSpace(this.Source.String() + this.EdgeRHS.String() + this.Attrs.String())
+	return this.indentString("")
+}
+
+func (this EdgeStmt) indentString(indent string) string {
+	return indent + strings.TrimSpace(this.Source.String() + this.EdgeRHS.String() + ` ` + this.Attrs.String())
 }
 
 func (this EdgeStmt) Walk(v Visitor) {
@@ -561,7 +589,11 @@ func NewNodeStmt(id, attrs Attrib) (*NodeStmt, error) {
 }
 
 func (this NodeStmt) String() string {
-	return strings.TrimSpace(this.NodeID.String() + ` ` + this.Attrs.String())
+	return this.indentString("")
+}
+
+func (this NodeStmt) indentString(indent string) string {
+	return indent + strings.TrimSpace(this.NodeID.String() + ` ` + this.Attrs.String())
 }
 
 func (this NodeStmt) Walk(v Visitor) {
@@ -695,4 +727,11 @@ func (this ID) Walk(v Visitor) {
 		return
 	}
 	v.Visit(this)
+}
+
+func genIndent(lvl int) (idt string) {
+	for i := 0; i < lvl; i++ {
+		idt += "\t"
+	}
+	return idt
 }

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -507,7 +507,7 @@ func (this EdgeStmt) String() string {
 }
 
 func (this EdgeStmt) indentString(indent string) string {
-	return indent + strings.TrimSpace(this.Source.String() + this.EdgeRHS.String() + ` ` + this.Attrs.String())
+	return indent + strings.TrimSpace(this.Source.String()+this.EdgeRHS.String()+` `+this.Attrs.String())
 }
 
 func (this EdgeStmt) Walk(v Visitor) {
@@ -593,7 +593,7 @@ func (this NodeStmt) String() string {
 }
 
 func (this NodeStmt) indentString(indent string) string {
-	return indent + strings.TrimSpace(this.NodeID.String() + ` ` + this.Attrs.String())
+	return indent + strings.TrimSpace(this.NodeID.String()+` `+this.Attrs.String())
 }
 
 func (this NodeStmt) Walk(v Visitor) {

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -110,9 +110,10 @@ func (this *Graph) String() string {
 	if this.Strict {
 		s += "strict "
 	}
-	s += this.Type.String() + " " + this.ID.String() + " {\n"
+	s += this.Type.String() + " " + this.ID.String() + " {\n\t"
 	if this.StmtList != nil {
-		s += this.StmtList.String()
+		lines := strings.Split(this.StmtList.String(), "\n")
+		s += strings.Join(lines, "\n\t")
 	}
 	s += "\n}\n"
 	return s
@@ -150,9 +151,10 @@ func (this StmtList) String() string {
 	for i := 0; i < len(this); i++ {
 		ss := this[i].String()
 		if len(ss) > 0 {
-			s += "\t" + ss + ";\n"
+			s += ss + ";\n"
 		}
 	}
+	s = strings.TrimSuffix(s, "\n")
 	return s
 }
 
@@ -220,11 +222,12 @@ func (this *SubGraph) String() string {
 	if strings.HasPrefix(gName, "anon") {
 		gName = ""
 	}
-	s := "subgraph " + this.ID.String() + " {\n"
+	s := "subgraph " + this.ID.String() + " {\n\t"
 	if this.StmtList != nil {
-		s += this.StmtList.String()
+		lines := strings.Split(this.StmtList.String(), "\n")
+		s += strings.Join(lines, "\n\t")
 	}
-	s += "\n}\n"
+	s += "\n}"
 	return s
 }
 

--- a/escape_test.go
+++ b/escape_test.go
@@ -65,7 +65,6 @@ func TestEscape(t *testing.T) {
 	"e-f";
 	"kasdf99 99" [ URL="<a" ];
 	7 [ URL="<a" ];
-
 }`) {
 		t.Fatalf("%s", s)
 	}
@@ -101,19 +100,14 @@ func TestClusterSubgraphs(t *testing.T) {
 	graphStr := `graph G {
 	cluster_2--cluster_1;
 	subgraph cluster0 {
-	subgraph cluster_1 {
+		subgraph cluster_1 {
 
-}
-;
-	subgraph cluster_2 {
+		};
+		subgraph cluster_2 {
 
-}
-;
-
-}
-;
+		};
+	};
 	"Code deployment";
-
 }`
 	if !strings.HasPrefix(s, graphStr) {
 		t.Fatalf("%s", s)

--- a/example_test.go
+++ b/example_test.go
@@ -30,7 +30,6 @@ func ExampleRead() {
 	//	Hello->World;
 	//	Hello;
 	//	World;
-	//
 	//}
 }
 
@@ -57,7 +56,6 @@ func ExampleNewGraph() {
 	//	Hello->World;
 	//	Hello;
 	//	World;
-	//
 	//}
 }
 
@@ -160,26 +158,25 @@ func ExampleMyOwnGraphStructure() {
 	s := output.String()
 	fmt.Println(s)
 	// Output: digraph matrix {
-	//	1->1[ label=0 ];
-	//	1->2[ label=5 ];
-	//	1->3[ label=0 ];
-	//	1->4[ label=0 ];
-	//	2->1[ label=0 ];
-	//	2->2[ label=0 ];
-	//	2->3[ label=0 ];
-	//	2->4[ label=0 ];
-	//	3->1[ label=0 ];
-	//	3->2[ label=0 ];
-	//	3->3[ label=0 ];
-	//	3->4[ label=0 ];
-	//	4->1[ label=2 ];
-	//	4->2[ label=1 ];
-	//	4->3[ label=0 ];
-	//	4->4[ label=0 ];
+	//	1->1 [ label=0 ];
+	//	1->2 [ label=5 ];
+	//	1->3 [ label=0 ];
+	//	1->4 [ label=0 ];
+	//	2->1 [ label=0 ];
+	//	2->2 [ label=0 ];
+	//	2->3 [ label=0 ];
+	//	2->4 [ label=0 ];
+	//	3->1 [ label=0 ];
+	//	3->2 [ label=0 ];
+	//	3->3 [ label=0 ];
+	//	3->4 [ label=0 ];
+	//	4->1 [ label=2 ];
+	//	4->2 [ label=1 ];
+	//	4->3 [ label=0 ];
+	//	4->4 [ label=0 ];
 	//	1;
 	//	2;
 	//	3;
 	//	4;
-	//
 	//}
 }

--- a/remove_test.go
+++ b/remove_test.go
@@ -69,23 +69,16 @@ func TestRemoveNode(t *testing.T) {
 	SupportingFunction:cluster_Supporting->CoreFunction:cluster_Core;
 	Hello->CoreFunction:cluster_Core;
 	subgraph cluster_Core {
-	CoreFunction;
-
-}
-;
+		CoreFunction;
+	};
 	subgraph cluster_Development {
-	DevelopmentFunction;
-
-}
-;
+		DevelopmentFunction;
+	};
 	subgraph cluster_Supporting {
-	SupportingFunction;
-
-}
-;
+		SupportingFunction;
+	};
 	Hello;
 	World;
-
 }
 `
 
@@ -102,22 +95,16 @@ func TestRemoveNode(t *testing.T) {
 	SupportingFunction:cluster_Supporting->CoreFunction:cluster_Core;
 	Hello->CoreFunction:cluster_Core;
 	subgraph cluster_Core {
-	CoreFunction;
-
-}
-;
+		CoreFunction;
+	};
 	subgraph cluster_Development {
 
-}
-;
+	};
 	subgraph cluster_Supporting {
-	SupportingFunction;
-
-}
-;
+		SupportingFunction;
+	};
 	Hello;
 	World;
-
 }
 `
 	if g.String() != expected {
@@ -134,20 +121,14 @@ func TestRemoveNode(t *testing.T) {
 	expected = `digraph G {
 	SupportingFunction:cluster_Supporting->CoreFunction:cluster_Core;
 	subgraph cluster_Core {
-	CoreFunction;
-
-}
-;
+		CoreFunction;
+	};
 	subgraph cluster_Development {
 
-}
-;
+	};
 	subgraph cluster_Supporting {
-	SupportingFunction;
-
-}
-;
-
+		SupportingFunction;
+	};
 }
 `
 	if g.String() != expected {
@@ -160,19 +141,14 @@ func TestRemoveNode(t *testing.T) {
 
 	expected = `digraph G {
 	subgraph cluster_Core {
-	CoreFunction;
-
-}
-;
+		CoreFunction;
+	};
 	subgraph cluster_Development {
 
-}
-;
+	};
 	subgraph cluster_Supporting {
 
-}
-;
-
+	};
 }
 `
 
@@ -187,17 +163,13 @@ func TestRemoveNode(t *testing.T) {
 	expected = `digraph G {
 	subgraph cluster_Core {
 
-}
-;
+	};
 	subgraph cluster_Development {
 
-}
-;
+	};
 	subgraph cluster_Supporting {
 
-}
-;
-
+	};
 }
 `
 
@@ -270,30 +242,22 @@ func TestRemoveSubGraph(t *testing.T) {
 	Hello->CoreFunction:cluster_Core;
 	Hello->cluster_FooBar;
 	subgraph cluster_Core {
-	label=Core;
-	CoreFunction;
-
-}
-;
+		label=Core;
+		CoreFunction;
+	};
 	subgraph cluster_Development {
-	label=Development;
-	DevelopmentFunction;
-
-}
-;
+		label=Development;
+		DevelopmentFunction;
+	};
 	subgraph cluster_FooBar {
 
-}
-;
+	};
 	subgraph cluster_Supporting {
-	label=Supporting;
-	SupportingFunction;
-
-}
-;
+		label=Supporting;
+		SupportingFunction;
+	};
 	Hello;
 	World;
-
 }
 `
 	if g.String() != expected {
@@ -310,24 +274,18 @@ func TestRemoveSubGraph(t *testing.T) {
 	Hello->CoreFunction:cluster_Core;
 	Hello->cluster_FooBar;
 	subgraph cluster_Core {
-	label=Core;
-	CoreFunction;
-
-}
-;
+		label=Core;
+		CoreFunction;
+	};
 	subgraph cluster_FooBar {
 
-}
-;
+	};
 	subgraph cluster_Supporting {
-	label=Supporting;
-	SupportingFunction;
-
-}
-;
+		label=Supporting;
+		SupportingFunction;
+	};
 	Hello;
 	World;
-
 }
 `
 	if g.String() != expected {
@@ -343,18 +301,14 @@ func TestRemoveSubGraph(t *testing.T) {
 	Hello->CoreFunction:cluster_Core;
 	Hello->cluster_FooBar;
 	subgraph cluster_Core {
-	label=Core;
-	CoreFunction;
-
-}
-;
+		label=Core;
+		CoreFunction;
+	};
 	subgraph cluster_FooBar {
 
-}
-;
+	};
 	Hello;
 	World;
-
 }
 `
 	if g.String() != expected {
@@ -370,11 +324,9 @@ func TestRemoveSubGraph(t *testing.T) {
 	Hello->cluster_FooBar;
 	subgraph cluster_FooBar {
 
-}
-;
+	};
 	Hello;
 	World;
-
 }
 `
 	if g.String() != expected {
@@ -389,7 +341,6 @@ func TestRemoveSubGraph(t *testing.T) {
 	Hello->World;
 	Hello;
 	World;
-
 }
 `
 	if g.String() != expected {


### PR DESCRIPTION
First of all, thanks for this library!

This pull request aims to improve the string representation of nested graphs. This is purely a visual change to the .dot source and because .dot is intended to be visualized by a tool anyway, I'd understand if this feature is deemed unnecessary.

Before:
```dot
digraph toplevel {
	34->35[ label="True" ];
	34->36[ label="False" ];
	subgraph cluster_myfunc {
	label=myfunc;
	32 [ label="__temp2 = \"tru\" + \"e\"" ];
	33 [ label="__temp1 = __temp2 + \"\"" ];
	34 [ label="__temp1" ];
	35 [ label="\"helloo\"" ];

}
;
	6 [ label="\"a\" + __temp1" ];
	7 [ label="__temp6 = \"a\" + \"b\"" ];
	8 [ label="__temp5 = __temp6 + \"c\"" ];
	9 [ label="__temp4 = __temp5 + \"d\"" ];

}
```

After:
```dot
digraph toplevel {
	34->35[ label="True" ];
	34->36[ label="False" ];
	subgraph cluster_myfunc {
		label=myfunc;
		32 [ label="__temp2 = \"tru\" + \"e\"" ];
		33 [ label="__temp1 = __temp2 + \"\"" ];
		34 [ label="__temp1" ];
		35 [ label="\"helloo\"" ];
	};
	6 [ label="\"a\" + __temp1" ];
	7 [ label="__temp6 = \"a\" + \"b\"" ];
	8 [ label="__temp5 = __temp6 + \"c\"" ];
	9 [ label="__temp4 = __temp5 + \"d\"" ];
}
```

There are a few issues with this PR as it stands, namely tests fail because they assume a certain structure of whitespace.   
Also the generation is slower, because I implemented the change without adjusting the `String()` interface and instead just split strings of sub-elements on newlines so that I can rejoin them with the correct indentation. I didn't benchmark this, but I think stringification is not a performance critical part of this library (?).

As for the tests, I wanted to ask for some feedback before continuing. I don't have a lot of experience in this area, but I feel there are 3 options:
1. Change the tests to reflect the new whitespace structure
2. Change tests to ignore whitespace when comparing (assuming dot ignores whitespace)
3. Change tests to check equality of output by parsing the generated output again and comparing the ASTs

Personally, I think 2. might be the best option, because 1. is just as unstable as the current tests and 3. might not catch cases where the library generates incorrect .dot, but also parses invalid .dot correctly back into an AST.

Do you have any inputs?